### PR TITLE
Prefix local macros for improved usability with Edition 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ The `delegate!` macro in this crate helps solve this problem by making your
 delegating methods more declarative:
 
 ```rust
-#[macro_use]
-extern crate delegate;
+use delegate::delegate;
 
 #[derive(Clone, Debug)]
 struct Stack<T> {
@@ -153,8 +152,7 @@ You may also delegate different methods to different fields inside the same
 `delegate!` block. For example:
 
 ```rust
-#[macro_use]
-extern crate delegate;
+use delegate::delegate;
 
 #[derive(Clone, Debug)]
 struct MultiStack<T> {

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ impl<T> Stack<T> {
 
 As you can see, `Vec` already supports most of the operations we needed, so in
 most cases our implementation is simply delegating to the underlying `Vec`,
-except ocassionally re-mapping the method to a different name (e.g. `peek()` is
+except occasionally re-mapping the method to a different name (e.g. `peek()` is
 called `last()` in `Vec`).
 
-The fact that these implemenations are boring (simply delegating to another
+The fact that these implementations are boring (simply delegating to another
 struct) is probably notable and worth calling out. If the reader of the code is
 already familiar with the behavior with the other struct, they can safely gloss
 over these methods and focus on the more interesting ones. Further more, if we
@@ -80,7 +80,7 @@ is well tested, we can probably just write a simple smoke test and not worry
 about re-testing the edge cases.
 
 Unfortunately, this detail could easily get lost, especially when these methods
-are burried within other non-delegating methods. The only way to be sure is to
+are buried within other non-delegating methods. The only way to be sure is to
 carefully read the implementation to confirm that they aren't doing anything
 more, which somewhat defeats the purpose.
 
@@ -131,7 +131,7 @@ hand in the example above (with one minor difference, see below). Not only did
 you save a few lines of typing, you are making your intent more clear to your
 readers as well.
 
-The macro support all the usual syntatic elements that are valid around method
+The macro support all the usual syntactic elements that are valid around method
 declarations, such as (doc) comments, attributes, `pub` modifiers, generics,
 lifetimes, return type and where clauses. The only difference is that instead
 of providing a block for the method body, you simply end it with a `;` after

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ macro_rules! delegate {
             buffer: { $($rest)* },
             stack: {
                 items: [],
-                action: delegate__expand
+                action: $crate::delegate__expand
             }
         }
     };
@@ -35,10 +35,10 @@ macro_rules! delegate__parse {
         buffer: {},
         stack: {
             items: [ $($items:tt)* ],
-            action: $action:tt
+            action: $action:path
         }
     } => {
-        $crate::$action ! { $($items)* }
+        $action ! { $($items)* }
     };
 
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ macro_rules! delegate {
     // entry point
 
     { $($rest:tt)* } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: top_level,
             buffer: { $($rest)* },
             stack: {
@@ -38,7 +38,7 @@ macro_rules! delegate__parse {
             action: $action:tt
         }
     } => {
-        $action ! { $($items)* }
+        $crate::$action ! { $($items)* }
     };
 
     {
@@ -46,7 +46,7 @@ macro_rules! delegate__parse {
         buffer: $buffer:tt,
         stack: $stack:tt
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_target,
             buffer: $buffer,
             stack: $stack
@@ -63,7 +63,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_methods,
             buffer: { $($methods)* },
             stack: {
@@ -87,7 +87,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: top_level,
             buffer: { $($rest)* },
             stack: {
@@ -105,7 +105,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_attributes,
             buffer: $buffer,
             stack: {
@@ -127,7 +127,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_attributes,
             buffer: { $($rest)* },
             stack: {
@@ -145,7 +145,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_attributes,
             buffer: { $($rest)* },
             stack: {
@@ -163,7 +163,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_attributes,
             buffer: { $($rest)* },
             stack: {
@@ -181,7 +181,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_attributes,
             buffer: { $($rest)* },
             stack: {
@@ -196,7 +196,7 @@ macro_rules! delegate__parse {
         buffer: $buffer:tt,
         stack: $stack:tt
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_visibility,
             buffer: $buffer,
             stack: $stack
@@ -213,7 +213,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_safety,
             buffer: { $($rest)* },
             stack: {
@@ -231,7 +231,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_safety,
             buffer: { $($rest)* },
             stack: {
@@ -246,7 +246,7 @@ macro_rules! delegate__parse {
         buffer: $buffer:tt,
         stack: $stack:tt
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_safety,
             buffer: $buffer,
             stack: $stack
@@ -263,7 +263,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_extern,
             buffer: { $($rest)* },
             stack: {
@@ -278,7 +278,7 @@ macro_rules! delegate__parse {
         buffer: $buffer:tt,
         stack: $stack:tt
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_extern,
             buffer: $buffer,
             stack: $stack
@@ -295,7 +295,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_name,
             buffer: { $($rest)* },
             stack: {
@@ -313,7 +313,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_name,
             buffer: { $($rest)* },
             stack: {
@@ -331,7 +331,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_name,
             buffer: { $($rest)* },
             stack: {
@@ -352,7 +352,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_generics,
             buffer: { $($rest)* },
             stack: {
@@ -373,7 +373,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_generics,
             buffer: { $($rest)* },
             stack: {
@@ -396,7 +396,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_generics,
             buffer: { $($rest)* },
             stack: {
@@ -416,7 +416,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_generics,
             buffer: { $($rest)* },
             stack: {
@@ -436,7 +436,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args,
             buffer: { $($rest)* },
             stack: {
@@ -455,7 +455,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_generics,
             buffer: { > $($rest)* },
             stack: {
@@ -474,7 +474,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args,
             buffer: $buffer,
             stack: {
@@ -492,7 +492,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_generics,
             buffer: { $($rest)* },
             stack: {
@@ -514,7 +514,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_self,
             buffer: { $($args)* },
             stack: {
@@ -541,9 +541,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: { $($rest)* },
             stack: {
@@ -567,9 +567,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: {},
             stack: {
@@ -593,9 +593,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: { $($rest)* },
             stack: {
@@ -619,9 +619,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: {},
             stack: {
@@ -645,9 +645,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: { $($rest)* },
             stack: {
@@ -671,9 +671,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: {},
             stack: {
@@ -697,9 +697,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: { $($rest)* },
             stack: {
@@ -723,9 +723,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: {},
             stack: {
@@ -749,9 +749,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: { $($rest)* },
             stack: {
@@ -775,9 +775,9 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__ensure_self!($self);
+        $crate::delegate__ensure_self!($self);
 
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: {},
             stack: {
@@ -801,7 +801,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: { $($rest)* },
             stack: {
@@ -821,7 +821,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_args_rest,
             buffer: {},
             stack: {
@@ -844,7 +844,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_return,
             buffer: { $($rest)* },
             stack: {
@@ -865,7 +865,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_end,
             buffer: { ; $($rest)* },
             stack: {
@@ -883,7 +883,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_where_clause,
             buffer: { where $($rest)* },
             stack: {
@@ -898,7 +898,7 @@ macro_rules! delegate__parse {
         buffer: $buffer:tt,
         stack: $stack:tt
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_where_clause,
             buffer: $buffer,
             stack: $stack
@@ -915,7 +915,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_where_clause,
             buffer: { $($rest)* },
             stack: {
@@ -935,7 +935,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_end,
             buffer: { ; $($rest)* },
             stack: {
@@ -954,7 +954,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_where_clause,
             buffer: { $($rest)* },
             stack: {
@@ -970,7 +970,7 @@ macro_rules! delegate__parse {
         buffer: $buffer:tt,
         stack: $stack:tt
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_method_end,
             buffer: $buffer,
             stack: $stack
@@ -990,7 +990,7 @@ macro_rules! delegate__parse {
             $($stack:tt)*
         }
     } => {
-        delegate__parse! {
+        $crate::delegate__parse! {
             state: parse_methods,
             buffer: { $($rest)* },
             stack: {
@@ -1011,7 +1011,7 @@ macro_rules! delegate__parse {
         buffer: { $token:tt $($rest:tt)* },
         stack: $stack:tt
     } => {
-        delegate__parse_fail!($token);
+        $crate::delegate__parse_fail!($token);
         compile_error!(concat!(
             "ParseError! ",
             "Unexpected token `", stringify!($token), "` in `", stringify!($state), "`. ",
@@ -1150,7 +1150,7 @@ mod tests {
     macro_rules! assert_delegation {
         { { $($actual:tt)* }, { $($expected:tt)* } } => {
             let actual = {
-                delegate__parse! {
+                $crate::delegate__parse! {
                     state: top_level,
                     buffer: { $($actual)* },
                     stack: {


### PR DESCRIPTION
This PR prefixes the `$crate` variable to all invocations of local macros in this library.

With Rust 2018, the recommended approach is now to `use macro` instead of `extern crate`. With this PR, the user is able to invoke `delegate!` with a single import:
```rust
use delegate::delegate;
```
instead of having to bring every local macro into view:
```rust
use delegate::{delegate, delegate__ensure_self, delegate__expand, delegate__parse};
```
@chancancode would you like to see the `README.md` updated as well?

Closes #6.