### PR TITLE
Allow using an empty or a different return type on delegated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ impl<T> MultiStack<T> {
 }
 ```
 
-You target field for delegation can also be nested:
+The target field for delegation can also be nested:
 ```rust
 struct Inner;
 impl Inner {
@@ -210,6 +210,29 @@ impl Wrapper {
     delegate! {
         target self.inner.inner {
             pub(crate) fn method(&self, num: u32) -> u32;
+        }
+    }
+}
+```
+
+You can change the return type of the delegated method.
+If you don't want to your delegating method to return anything, you can omit the return type
+from the declaration. This will cause the method to return `()`.
+Or you can choose a different datatype which can be converted using the `From` trait from the
+original datatype.
+
+```rust
+struct Inner;
+impl Inner {
+    pub fn method1(&self, num: u32) -> u32 { num }
+    pub fn method2(&self, num: u32) -> u32 { num }
+}
+struct Wrapper { inner: Inner }
+impl Wrapper {
+    delegate! {
+        target self.inner.inner {
+            pub fn method(&self, num: u32);
+            pub fn method2(&self, num: u32) -> u64;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,13 +187,18 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
             let visibility = &method.visibility;
 
             let span = input.span();
-            quote::quote_spanned! {span=>
-            #(#attrs)*
-            #inline
-            #visibility #signature {
-                #delegator_attribute.#name(#(#args),*)
+            let terminator = match &signature.decl.output {
+                syn::ReturnType::Default => quote::quote! { ; },
+                _ => quote::quote! { .into() }
+            };
+
+            quote::quote_spanned! { span =>
+                #(#attrs)*
+                #inline
+                #visibility #signature {
+                    #delegator_attribute.#name(#(#args),*)#terminator
+                }
             }
-        }
         });
 
         quote! { #(#functions)* }

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -9,7 +9,7 @@ impl Inner {
 }
 
 struct Inner2 {
-    inner: Inner
+    inner: Inner,
 }
 
 struct Wrapper {
@@ -27,9 +27,7 @@ impl Wrapper {
 #[test]
 fn test_nested() {
     let wrapper = Wrapper {
-        inner: Inner2 {
-            inner: Inner
-        }
+        inner: Inner2 { inner: Inner },
     };
 
     assert_eq!(wrapper.method(3), 3);

--- a/tests/returntype.rs
+++ b/tests/returntype.rs
@@ -1,32 +1,69 @@
 extern crate delegate;
 use delegate::delegate;
 
-struct Inner;
-impl Inner {
-    pub fn method(&self, num: u32) -> u32 {
-        num
-    }
-}
-
-struct Wrapper {
-    inner: Inner,
-}
-
-impl Wrapper {
-    delegate! {
-        target self.inner {
-            pub(crate) fn method(&self, num: u32);
-
-            #[target_method(method)]
-            pub(crate) fn method_conv(&self, num: u32) -> u64;
-        }
-    }
-}
-
 #[test]
 fn test_rettype() {
+    struct Inner;
+    impl Inner {
+        pub fn method(&self, num: u32) -> u32 {
+            num
+        }
+    }
+
+    struct Wrapper {
+        inner: Inner,
+    }
+
+    impl Wrapper {
+        delegate! {
+            target self.inner {
+                pub(crate) fn method(&self, num: u32);
+
+                #[into]
+                #[target_method(method)]
+                pub(crate) fn method_conv(&self, num: u32) -> u64;
+            }
+        }
+    }
+
     let wrapper = Wrapper { inner: Inner };
 
     assert_eq!(wrapper.method(3), ());
     assert_eq!(wrapper.method_conv(3), 3u64);
+}
+
+#[test]
+fn test_rettype_generic() {
+    trait TestTrait {
+        fn create(num: u32) -> Self;
+    }
+    impl TestTrait for u32 {
+        fn create(num: u32) -> Self {
+            num
+        }
+    }
+
+    struct Inner;
+    impl Inner {
+        pub fn method<T: TestTrait>(&self) -> T {
+            T::create(0)
+        }
+    }
+
+    struct Wrapper<T> {
+        inner: Inner,
+        s: T,
+    }
+
+    impl<T: TestTrait> Wrapper<T> {
+        delegate! {
+            target self.inner {
+                pub(crate) fn method(&self) -> T;
+            }
+        }
+    }
+
+    let wrapper = Wrapper { inner: Inner, s: 3 };
+
+    assert_eq!(wrapper.method(), 0);
 }

--- a/tests/returntype.rs
+++ b/tests/returntype.rs
@@ -1,0 +1,32 @@
+extern crate delegate;
+use delegate::delegate;
+
+struct Inner;
+impl Inner {
+    pub fn method(&self, num: u32) -> u32 {
+        num
+    }
+}
+
+struct Wrapper {
+    inner: Inner,
+}
+
+impl Wrapper {
+    delegate! {
+        target self.inner {
+            pub(crate) fn method(&self, num: u32);
+
+            #[target_method(method)]
+            pub(crate) fn method_conv(&self, num: u32) -> u64;
+        }
+    }
+}
+
+#[test]
+fn test_rettype() {
+    let wrapper = Wrapper { inner: Inner };
+
+    assert_eq!(wrapper.method(3), ());
+    assert_eq!(wrapper.method_conv(3), 3u64);
+}


### PR DESCRIPTION
Fixes https://github.com/chancancode/rust-delegate/issues/10