### PR TITLE
Rename target_method attribute to call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ impl<T> Stack<T> {
     delegate! {
         to self.inner {
             /// The number of items in the stack
-            #[target_method(len)]
+            #[call(len)]
             pub fn size(&self) -> usize;
 
             /// Whether the stack is empty
@@ -116,7 +116,7 @@ impl<T> Stack<T> {
             pub fn pop(&mut self) -> Option<T>;
 
             /// Accessing the top item without removing it from the stack
-            #[target_method(last)]
+            #[call(last)]
             pub fn peek(&self) -> Option<&T>;
 
             /// Remove all items from the stack
@@ -144,7 +144,7 @@ inserting an  explicit `#[inline]` attribute (such as `#[inline(always)]` or
 
 As seen in the example above, if the name of the method does not match, you can
 override the inferred name (same name as your struct method) with the custom
-`#[target_method(...)]` attribute. (This attribute is removed by the macro
+`#[call(...)]` attribute. (This attribute is removed by the macro
 during expansion, so it does not rely on the experimental "custom_attribute"
 feature.)
 
@@ -168,20 +168,20 @@ impl<T> MultiStack<T> {
     delegate! {
         to self.left {
             /// Push an item to the top of the left stack
-            #[target_method(push)]
+            #[call(push)]
             pub fn push_left(&mut self, value: T);
 
             /// Remove an item from the top of the left stack
-            #[target_method(pop)]
+            #[call(pop)]
             pub fn pop_left(&mut self, value: T);
         }
         to self.right {
             /// Push an item to the top of the right stack
-            #[target_method(push)]
+            #[call(push)]
             pub fn push_right(&mut self, value: T);
 
             /// Remove an item from the top of the right stack
-            #[target_method(pop)]
+            #[call(pop)]
             pub fn pop_right(&mut self, value: T);
         }
     }

--- a/tests/returntype.rs
+++ b/tests/returntype.rs
@@ -20,7 +20,7 @@ fn test_rettype() {
                 pub(crate) fn method(&self, num: u32);
 
                 #[into]
-                #[target_method(method)]
+                #[call(method)]
                 pub(crate) fn method_conv(&self, num: u32) -> u64;
             }
         }

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -15,7 +15,7 @@ impl<T> Stack<T> {
     delegate! {
         to self.inner {
             #[inline(never)]
-            #[target_method(len)]
+            #[call(len)]
             pub(crate) fn size(&self) -> usize;
 
             /// doc comment
@@ -25,7 +25,7 @@ impl<T> Stack<T> {
             fn push(&mut self, v: T);
             pub fn pop(&mut self) -> Option<T>;
 
-            #[target_method(last)]
+            #[call(last)]
             #[inline(never)]
             fn peek(&self) -> Option<&T>;
             fn clear(&mut self);


### PR DESCRIPTION
Fixes https://github.com/chancancode/rust-delegate/issues/16