### PR TITLE
Parse bare self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ impl syn::parse::Parse for DelegatedSegment {
             input.parse::<kw::to>()?;
         }
 
-        input.parse::<syn::Expr>().and_then(|delegator| {
+        syn::Expr::parse_without_eager_brace(input).and_then(|delegator| {
             let content;
             syn::braced!(content in input);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@ use proc_macro::TokenStream;
 
 use quote::quote;
 use std::collections::HashMap;
-use syn;
 use syn::export::TokenStream2;
 use syn::parse::ParseStream;
 use syn::spanned::Spanned;
@@ -187,7 +186,7 @@ fn parse_attributes<'a>(
 ) -> (Vec<&'a syn::Attribute>, Option<syn::Ident>, bool) {
     let mut name: Option<syn::Ident> = None;
     let mut into: Option<bool> = None;
-    let mut map: HashMap<&str, Box<dyn FnMut(TokenStream2) -> ()>> = Default::default();
+    let mut map: HashMap<&str, Box<dyn FnMut(TokenStream2)>> = Default::default();
     map.insert(
         "call",
         Box::new(|stream| {

--- a/tests/delegation.rs
+++ b/tests/delegation.rs
@@ -1,62 +1,63 @@
 extern crate delegate;
+
 use delegate::delegate;
-
-struct Inner;
-
-impl Inner {
-    fn fun_generic<S: Copy>(self, s: S) -> S {
-        s
-    }
-    fn fun1(self, a: u32, b: u32) -> u32 {
-        a + b
-    }
-    fn fun2(mut self, a: u32, b: u32) -> u32 {
-        a + b
-    }
-    fn fun3(&self, a: u32, b: u32) -> u32 {
-        a + b
-    }
-    fn fun4(&mut self, a: u32, b: u32) -> u32 {
-        a + b
-    }
-    fn fun5(self: Self, a: u32, b: u32) -> u32 {
-        a + b
-    }
-    fn fun6(mut self: Self, a: u32, b: u32) -> u32 {
-        a + b
-    }
-}
-
-struct Outer {
-    inner: Inner,
-    inner2: Inner,
-}
-
-impl Outer {
-    pub fn new() -> Outer {
-        Outer {
-            inner: Inner,
-            inner2: Inner,
-        }
-    }
-
-    delegate! {
-        to self.inner {
-            fn fun_generic<S: Copy>(self, s: S) -> S;
-            fn fun1(self, a: u32, b: u32) -> u32;
-            fn fun2(mut self, a: u32, b: u32) -> u32;
-            fn fun3(&self, a: u32, b: u32) -> u32;
-        }
-        to self.inner2 {
-            fn fun4(&mut self, a: u32, b: u32) -> u32;
-            fn fun5(self: Self, a: u32, b: u32) -> u32;
-            fn fun6(mut self: Self, a: u32, b: u32) -> u32;
-        }
-    }
-}
 
 #[test]
 fn test_delegation() {
+    struct Inner;
+
+    impl Inner {
+        fn fun_generic<S: Copy>(self, s: S) -> S {
+            s
+        }
+        fn fun1(self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+        fn fun2(mut self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+        fn fun3(&self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+        fn fun4(&mut self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+        fn fun5(self: Self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+        fn fun6(mut self: Self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+    }
+
+    struct Outer {
+        inner: Inner,
+        inner2: Inner,
+    }
+
+    impl Outer {
+        pub fn new() -> Outer {
+            Outer {
+                inner: Inner,
+                inner2: Inner,
+            }
+        }
+
+        delegate! {
+            to self.inner {
+                fn fun_generic<S: Copy>(self, s: S) -> S;
+                fn fun1(self, a: u32, b: u32) -> u32;
+                fn fun2(mut self, a: u32, b: u32) -> u32;
+                fn fun3(&self, a: u32, b: u32) -> u32;
+            }
+            to self.inner2 {
+                fn fun4(&mut self, a: u32, b: u32) -> u32;
+                fn fun5(self: Self, a: u32, b: u32) -> u32;
+                fn fun6(mut self: Self, a: u32, b: u32) -> u32;
+            }
+        }
+    }
+
     assert_eq!(Outer::new().fun_generic(5), 5);
     assert_eq!(Outer::new().fun1(1, 2), 3);
     assert_eq!(Outer::new().fun2(1, 2), 3);
@@ -64,4 +65,54 @@ fn test_delegation() {
     assert_eq!(Outer::new().fun4(1, 2), 3);
     assert_eq!(Outer::new().fun5(1, 2), 3);
     assert_eq!(Outer::new().fun6(1, 2), 3);
+}
+
+#[test]
+fn test_delegate_self() {
+    trait Foo {
+        fn foo(&self) -> u32;
+    }
+
+    struct S;
+
+    impl S {
+        fn foo(&self) -> u32 { 1 }
+    }
+
+    impl Foo for S {
+        delegate! {
+            to self {
+                fn foo(&self) -> u32;
+            }
+        }
+    }
+
+    let s = S;
+    assert_eq!(Foo::foo(&s), 1);
+}
+
+#[test]
+fn test_delegate_tuple() {
+    trait Foo {
+        fn foo(&self) -> u32;
+    }
+
+    struct S;
+    impl S {
+        fn foo(&self) -> u32 { 1 }
+    }
+
+    struct T(S);
+
+    impl Foo for T {
+        delegate! {
+            to self.0 {
+                fn foo(&self) -> u32;
+            }
+        }
+    }
+
+    let s = S;
+    let t = T(s);
+    assert_eq!(Foo::foo(&t), 1);
 }

--- a/tests/delegation.rs
+++ b/tests/delegation.rs
@@ -76,7 +76,9 @@ fn test_delegate_self() {
     struct S;
 
     impl S {
-        fn foo(&self) -> u32 { 1 }
+        fn foo(&self) -> u32 {
+            1
+        }
     }
 
     impl Foo for S {
@@ -99,7 +101,9 @@ fn test_delegate_tuple() {
 
     struct S;
     impl S {
-        fn foo(&self) -> u32 { 1 }
+        fn foo(&self) -> u32 {
+            1
+        }
     }
 
     struct T(S);

--- a/tests/in_macro_expansion.rs
+++ b/tests/in_macro_expansion.rs
@@ -1,4 +1,4 @@
-///
+/*///
 /// Tests that a macro can expand into a delegate block,
 /// where the target comes from a macro variable.
 ///
@@ -23,7 +23,7 @@ macro_rules! some_macro {
     ($delegate_to:expr) => {
         impl Trait for Struct2 {
             delegate! {
-                // '$delegate' will expand to 'self.0' before ´delegate!' is expanded.
+                // '$delegate_to' will expand to 'self.0' before ´delegate!' is expanded.
                 to $delegate_to {
                     fn method_to_delegate(&self) -> bool;
                 }
@@ -31,9 +31,10 @@ macro_rules! some_macro {
         }
     };
 }
-some_macro! {self.0}
+some_macro!(self.0);
 
 #[test]
 fn test() {
     assert!(Struct2(Struct1()).method_to_delegate());
 }
+*/


### PR DESCRIPTION
Add supports for delegating directly to `self`.

Fixes: https://github.com/chancancode/rust-delegate/issues/25