### PR TITLE
FIX: USE SYN'S PRIVATE API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,10 +87,10 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 
 use quote::quote;
 use std::collections::HashMap;
-use syn::export::TokenStream2;
 use syn::parse::ParseStream;
 use syn::spanned::Spanned;
 use syn::Error;


### PR DESCRIPTION
syn has broken one of its private API, this commit follows that change,
until a migration to a public API is completed.

See more at:
https://github.com/dtolnay/syn/commit/957840eba2c7f11c95e0227760d78dc481a91de7

Closes #28